### PR TITLE
Added Dockerfiles with instructions for running fleet adapter using RMF 22.09

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -yr
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release 
 ```
 
-**Alternatively**, if you like to use **Docker** and avoid the hassle of resolving dependency conflicts, please run the commands below instead:
+:whale: **Alternatively**, if you like to use **Docker** and avoid the hassle of resolving dependency conflicts, please run the commands below instead:
 
 ```bash
 cd $HOME && git clone https://github.com/lionsbot-official/fleet_adapter_lionsbot --branch rmf/22.09 --single-branch --depth 1
@@ -82,7 +82,7 @@ cd fleet_adapter_lionsbot && docker build -f leoscrub_Dockerfile -t fleet_adapte
 ros2 run fleet_adapter_r3 fleet_adapter_r3 -c config.yaml -n nav_graph.yaml -d dock_summary.yaml
 ```
 
-**Alternatively**, if you used the **Docker** instructions above to build, please run the commands below instead:
+:whale: **Alternatively**, if you used the **Docker** instructions above to build, please run the commands below instead:
 
 Build and run docker container for `fleet_adapter_r3`:
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ Currently, fleet adapters are developed and has been tested for these supported 
 
 > **NOTE**: `pause_task` and `continue_task` are custom tasks. The python scripts have to be added into where the rest of the official tasks are located.
 
+## Building the fleet adapter
+
+```bash
+cd $HOME && mkdir -p fleet_adapter_lionsbot_ws/src
+```
+
+```bash
+cd fleet_adapter_lionsbot_ws/
+```
+
+```bash
+git clone https://github.com/lionsbot-official/fleet_adapter_lionsbot --branch rmf/22.09 --single-branch --depth 1 src
+```
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+```bash
+rosdep update --rosdistro $ROS_DISTRO
+```
+
+```bash
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -yr
+```
+
+```bash
+colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release 
+```
+
 ## Running the fleet adapter
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,8 +60,52 @@ rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -yr
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release 
 ```
 
+**Alternatively**, if you like to use **Docker** and avoid the hassle of resolving dependency conflicts, please run the commands below instead:
+
+```bash
+cd $HOME && git clone https://github.com/lionsbot-official/fleet_adapter_lionsbot --branch rmf/22.09 --single-branch --depth 1
+```
+
+Build docker image for `fleet_adapter_r3`:
+```bash
+cd fleet_adapter_lionsbot && docker build -f r3_Dockerfile -t fleet_adapter_lionsbot:r3
+```
+
+Build docker image for `fleet_adapter_leoscrub`:
+```bash
+cd fleet_adapter_lionsbot && docker build -f leoscrub_Dockerfile -t fleet_adapter_lionsbot:leoscrub
+```
+
 ## Running the fleet adapter
 
 ```
 ros2 run fleet_adapter_r3 fleet_adapter_r3 -c config.yaml -n nav_graph.yaml -d dock_summary.yaml
+```
+
+**Alternatively**, if you used the **Docker** instructions above to build, please run the commands below instead:
+
+Build and run docker container for `fleet_adapter_r3`:
+```bash
+docker run -it --rm  \
+--network host \
+-v /dev/shm:/dev/shm \
+--name fleet_adapter_lionsbot_r3_c \
+fleet_adapter_lionsbot:r3 bash -c \
+"ros2 run fleet_adapter_r3 fleet_adapter \
+-c config.yaml \
+-n nav_graph.yaml \
+-d dock_summary.yaml"
+```
+
+Build and run docker container for `fleet_adapter_leoscrub`:
+```bash
+docker run -it --rm  \
+--network host \
+-v /dev/shm:/dev/shm \
+--name fleet_adapter_lionsbot_leoscrub_c \
+fleet_adapter_lionsbot:leoscrub bash -c \
+"ros2 run fleet_adapter_leoscrub fleet_adapter \
+-c config.yaml \
+-n nav_graph.yaml \
+-d dock_summary.yaml"
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently, fleet adapters are developed and has been tested for these supported 
 
 | RMF Version | Installation Instructions     | Supported distros | Supported ROS2 versions |
 |-------|-------------------------------|-------------------|-----------------------|
-| 21.09 | [Installation Instructions](https://github.com/open-rmf/rmf/tree/release/21.09) | Ubuntu 20.04, Ubuntu 21.09, RHEL 8 (deployment only) | Foxy, Galactic |
+| 22.09 | [Installation Instructions](https://github.com/open-rmf/rmf/tree/release/22.09) | Ubuntu 22.04 | Humble |
 
 ## Tasks Summary
 

--- a/leoscrub_Dockerfile
+++ b/leoscrub_Dockerfile
@@ -1,0 +1,37 @@
+FROM ghcr.io/open-rmf/rmf/rmf_demos:22_09
+
+RUN apt-get update \
+  && apt-get remove python3-starlette -y \
+  && apt-get install -y \
+    cmake \
+    curl \
+    git \
+    python3-colcon-common-extensions \
+    python3-vcstool \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    wget \
+    python3-pip \
+  && pip3 install flask-socketio fastapi uvicorn nudged websocket-client pyjwt \
+  && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+WORKDIR /fleet_adapter_leoscrub_ws
+RUN mkdir src
+
+# This replaces: wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rosdep update --rosdistro $ROS_DISTRO \
+    && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -yr \
+    && rm -rf /var/lib/apt/lists/*
+
+# colcon compilation
+COPY fleet_adapter_leoscrub src/fleet_adapter_leoscrub
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release 
+
+# cleanup
+RUN sed -i '$isource "/fleet_adapter_leoscrub_ws/install/setup.bash"' /ros_entrypoint.sh
+
+ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/r3_Dockerfile
+++ b/r3_Dockerfile
@@ -1,0 +1,37 @@
+FROM ghcr.io/open-rmf/rmf/rmf_demos:22_09
+
+RUN apt-get update \
+  && apt-get remove python3-starlette -y \
+  && apt-get install -y \
+    cmake \
+    curl \
+    git \
+    python3-colcon-common-extensions \
+    python3-vcstool \
+    qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    wget \
+    python3-pip \
+  && pip3 install flask-socketio fastapi uvicorn nudged websocket-client pyjwt \
+  && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+WORKDIR /fleet_adapter_r3_ws
+RUN mkdir src
+
+# This replaces: wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rosdep update --rosdistro $ROS_DISTRO \
+    && rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -yr \
+    && rm -rf /var/lib/apt/lists/*
+
+# colcon compilation
+COPY fleet_adapter_r3 src/fleet_adapter_r3
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release 
+
+# cleanup
+RUN sed -i '$isource "/fleet_adapter_r3_ws/install/setup.bash"' /ros_entrypoint.sh
+
+ENTRYPOINT ["/ros_entrypoint.sh"]


### PR DESCRIPTION
## **What Is This For?**

This pull request is to make available a dockerised approach when using `fleet_adapter_r3` and `fleet_adapter_leoscrub` as well as update the root `README.md` on how to properly use it.

The modifications made should allow new users of the fleet adapter to quickly set up and utilise for their respective RMF use case.

## **Summary** :bookmark_tabs: 
- Added 2 `Dockerfiles` in root of repository.
- Updated `README.md` to reflect proper use of added `Dockerfile`s.
- Updated `README.md`'s RMF Installation section to `RMF 22.09`.

## **Caveats** :eye_speech_bubble: :arrow_double_down: 
- Both `Dockerfile` for `fleet_adapter_r3` and `fleet_adapter_leoscrub` are using docker base image `ghcr.io/open-rmf/rmf/rmf_demos:22_09`. Reason being, building RMF from scratch using the `ros:humble-ros-core` base image proved to incur high build times, making it impractical to use. Furthermore, the docker memory optimization using the "proper" approach only saves about `0.5GB` of space. Therefore, opted to simply use the former docker image base for faster build time.

The current docker memory using `ghcr.io/open-rmf/rmf/rmf_demos:22_09` is around `5.5GB`.

- Current dockerization will still fail due to the use of custom `rmf_litter_msgs` dependency. This dependency in internal discussions will be removed in a patch which will come soon. Will update in this thread once the removal has been done.

## **Remarks** :speech_balloon: 
This pull request (PR) will be one of a set which will include features from a verified implementation of `fleet_adapter_r3`. Aimed at making the rest incrementally over the span between **19th August 2024** to **2nd September 2024**.