### PR TITLE
Rectified docker setup instructions in root README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ docker run -it --rm  \
 --name fleet_adapter_lionsbot_r3_c \
 fleet_adapter_lionsbot:r3 bash -c \
 "ros2 run fleet_adapter_r3 fleet_adapter \
--c config.yaml \
--n nav_graph.yaml \
--d dock_summary.yaml"
+-c /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/config.yaml \
+-n /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/nav_graph.yaml \
+-d /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/dock_summary.yaml"
 ```
 
 Build and run docker container for `fleet_adapter_leoscrub`:
@@ -109,7 +109,7 @@ docker run -it --rm  \
 --name fleet_adapter_lionsbot_leoscrub_c \
 fleet_adapter_lionsbot:leoscrub bash -c \
 "ros2 run fleet_adapter_leoscrub fleet_adapter \
--c config.yaml \
--n nav_graph.yaml \
--d dock_summary.yaml"
+-c /fleet_adapter_leoscrub_ws/src/fleet_adapter_leoscrub/configs/config.yaml \
+-n /fleet_adapter_leoscrub_ws/src/fleet_adapter_leoscrub/configs/nav_graph.yaml \
+-d /fleet_adapter_leoscrub_ws/src/fleet_adapter_leoscrub/configs/dock_summary.yaml"
 ```

--- a/README.md
+++ b/README.md
@@ -63,17 +63,21 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 :whale: **Alternatively**, if you like to use **Docker** and avoid the hassle of resolving dependency conflicts, please run the commands below instead:
 
 ```bash
-cd $HOME && git clone https://github.com/lionsbot-official/fleet_adapter_lionsbot --branch rmf/22.09 --single-branch --depth 1
+cd $HOME 
+```
+
+```bash
+git clone https://github.com/lionsbot-official/fleet_adapter_lionsbot --branch rmf/22.09 --single-branch --depth 1 && cd fleet_adapter_lionsbot
 ```
 
 Build docker image for `fleet_adapter_r3`:
 ```bash
-cd fleet_adapter_lionsbot && docker build -f r3_Dockerfile -t fleet_adapter_lionsbot:r3
+docker build -f r3_Dockerfile -t fleet_adapter_lionsbot:r3 .
 ```
 
 Build docker image for `fleet_adapter_leoscrub`:
 ```bash
-cd fleet_adapter_lionsbot && docker build -f leoscrub_Dockerfile -t fleet_adapter_lionsbot:leoscrub
+docker build -f leoscrub_Dockerfile -t fleet_adapter_lionsbot:leoscrub .
 ```
 
 ## Running the fleet adapter


### PR DESCRIPTION
## Purpose of Pull Request :bookmark_tabs: 

This is to introduce **a quick correction** to the **docker set-up** and **run** instructions in the root `README.md`.

Allowed for easier copy-pasting during docker set-up and run process. Verified now with removal of previous `rmf_litter_msgs` dependency.