### PR TITLE
Reimplemented navigation_completed function call in RobotClientAPI.py

### DIFF
--- a/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
@@ -279,6 +279,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                         rmf_coord=target_pose_rmf
                     )
 
+                    self.api.target_position = target_pose_robot
+
                     robot_status = self.api.get_robot_status(robot_name=self.name)
                     while robot_status is None:
                         robot_status = self.api.get_robot_status(robot_name=self.name)


### PR DESCRIPTION
## Purpose of Pull Request :bookmark_tabs: 

This is to replace the existing approach of how `navigation_completed` should return `True` when `follow_new_path` is triggered by RMF Core. 

While the existing approach utilises the states in which a LionsBot R3 would output when navigation is truly done, ongoing test reveals that it is still too unreliable to rely on such state reading. 

Therefore, as a replacement, `navigation_completed` should now `True` when the following condition is met:

Robot Position (provided by API call) is close enough to the target waypoint.

## **Remarks** :speech_balloon: 

This replacement may warrant further discussion before reviewing. Please feel free to contact me over our usual internal discussion channels. 