### PR TITLE
Added optional Navigation by Localization Points

### DIFF
--- a/fleet_adapter_r3/fleet_adapter_r3/RobotClientAPI.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotClientAPI.py
@@ -1080,3 +1080,37 @@ class RobotAPI:
             print(f'HTTP error: {http_err}')
 
         return False
+    
+    def get_waypoint_position(self, robot_name: str, map_name: str, waypoint_name: str):
+        self.refresh_expired_token()
+
+        map_data = self.get_map(map_name=map_name, robot_name=robot_name)
+        if map_data is None:
+            return False
+
+        map_id = map_data['id']
+
+        # Defining API path for getting robot position.
+        path = f'{constants.OPEN_API_PREFIX}/worksitemap/locpoint/{map_id}'
+        headers = {'Authorization': f'Bearer {self.token}'}
+    
+        # Sending API call for getting robot position.
+        try:
+            r = requests.get(f'https://{self.prefix}{path}', headers=headers)
+            r.raise_for_status()
+            data = r.json()
+    
+            for local_element in data:
+                if local_element['name'] == waypoint_name:
+                    parts = local_element['coordinates'].split()
+    
+                    x = int(parts[0])  
+                    y = int(parts[1]) 
+    
+                    waypoint_position = LionsbotCoord(x, y, local_element['angle'])
+                    return waypoint_position
+
+        except requests.exceptions.ConnectionError as connection_error:
+            print(f'Connection error: {connection_error}')
+        except HTTPError as http_err:
+            print(f'HTTP error: {http_err}')

--- a/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
@@ -300,8 +300,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                         # Move robot to next waypoint
                         is_waypoint = False
                         for waypoint_name in self.waypoint_network:
-                            if (self.target_waypoint.position[0] == self.waypoint_network[waypoint_name][0] and
-                                self.target_waypoint.position[1] == self.waypoint_network[waypoint_name][1]):
+                            if (self.target_waypoint.position.x == self.waypoint_network[waypoint_name][0] and
+                                self.target_waypoint.position.y == self.waypoint_network[waypoint_name][1]):
                                 target_pose_robot = self.api.get_waypoint_position(self.name, self.map_name, waypoint_name)
                     else:
                         target_pose_rmf = self.target_waypoint.position

--- a/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
@@ -79,7 +79,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                  update_frequency,
                  adapter,
                  api:RobotAPI,
-                 safe_nav_flag,
+                 use_safe_nav,
                  waypoints_info):
         adpt.RobotCommandHandle.__init__(self)
         self.name = name
@@ -113,7 +113,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         self.path_index = 0
         self.docking_finished_callback = None
 
-        self.use_safe_nav = safe_nav_flag
+        self.use_safe_nav = use_safe_nav
         self.waypoint_network = waypoints_info
 
         # RMF location trackers

--- a/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
@@ -298,7 +298,6 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
                     if self.use_safe_nav:
                         # Move robot to next waypoint
-                        is_waypoint = False
                         for waypoint_name in self.waypoint_network:
                             if (self.target_waypoint.position.x == self.waypoint_network[waypoint_name][0] and
                                 self.target_waypoint.position.y == self.waypoint_network[waypoint_name][1]):

--- a/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotCommandHandle.py
@@ -297,7 +297,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     self.node.get_logger().info(f'Attempting to navigate in map: {current_map_name}')
 
                     if self.use_safe_nav:
-                        # Move robot to next waypoint
+                        # Search through all waypoints to get matching waypoint.
+                        # Once found, make API call to get LionsbotCoord of matching waypoint.
                         for waypoint_name in self.waypoint_network:
                             if (self.target_waypoint.position.x == self.waypoint_network[waypoint_name][0] and
                                 self.target_waypoint.position.y == self.waypoint_network[waypoint_name][1]):

--- a/fleet_adapter_r3/fleet_adapter_r3/fleet_adapter.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/fleet_adapter.py
@@ -269,8 +269,8 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time, server_uri
                     node.get_logger().info(f"Subscribing to robot: {robot_name}")
                     api.subscribe_to_robot(robot_name, time.time_ns() / 1000000)
 
+                    waypoints_info = {}
                     if safe_nav_flag:
-                        waypoints_info = {}
                         with open(nav_graph_path, 'r') as file:
                             data = yaml.safe_load(file)
                             data = data['levels'][rmf_config['start']['map_name']]['vertices']

--- a/fleet_adapter_r3/fleet_adapter_r3/fleet_adapter.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/fleet_adapter.py
@@ -438,7 +438,8 @@ def main(argv=sys.argv):
         server_uri = args.server_uri
 
     if args.use_safe_nav:
-        print('USING SAFE : Navigating via Robot Localization Points')
+        print('USING SAFE_NAV : Navigating via Robot Localization Points')
+        print('Please ensure that Robot Map has waypoints same as RMF Map.')
         safe_nav_flag = True
     else:
         safe_nav_flag = False


### PR DESCRIPTION
## What Is This For? :bookmark: 

This pull request adds **an optional method of navigation heavily relying on API calls** to get waypoints of the same name on RMF Map from the actual Robot Map, instead solely relying on the MapTransform to convert RMF coordinates to LionsBot coordinates. 

This method seeks to **provide a straight-forward way of guaranteeing that the robot will be able to navigate to valid waypoints**, rather than obscure map-transformed custom waypoints as deduced via `nudged`. 

It also avoids encountering navigational issues which are difficult to debug due to the lack of proper error reporting on LionsBot R3 Scrub. This behaviour is noted in internal discussions as the **Flashing Error** where, when sent a navigation goal to an impossible location, the robot would flash the error on its on-board tablet before the developer could see what it is to debug.

This feature can be used easily via the following `docker run command`:

```bash 
docker run -it --rm  \
--network host \
-v /dev/shm:/dev/shm \
--name fleet_adapter_lionsbot_r3_c \
fleet_adapter_lionsbot:r3 bash -c \
"ros2 run fleet_adapter_r3 fleet_adapter \
--use_safe_nav \
-c /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/config.yaml \
-n /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/nav_graph.yaml \
-d /fleet_adapter_r3_ws/src/fleet_adapter_r3/configs/dock_summary.yaml"


```

## Summary 📑

- Implemented optional commandline flag `--use_safe_nav` which users can run the navigation calls using this methodology.
- Modified initialization of `RobotCommandHandle` class to include storing mappings between RMF Waypoint Names and RMF Waypoint Coordinate X-Y values.
- Modified function `follow_new_path` to fetch waypoint name and subsequently fetch Robot Map coordinate using the resulting name before making the Navigation Request API call.

## Caveats 👁️‍🗨️ ⏬

This method assumes that the Robot Map should have waypoints of the same name 
