### PR TITLE
chore: define wss origin using https

### DIFF
--- a/fleet_adapter_leoscrub/fleet_adapter_leoscrub/RobotClientAPI.py
+++ b/fleet_adapter_leoscrub/fleet_adapter_leoscrub/RobotClientAPI.py
@@ -187,7 +187,7 @@ class RobotAPI:
                                                                  on_close=on_close,
                                                                  on_error=on_error,
                                                                  on_message=on_message)
-        self.robot_status_ws_connection.run_forever()
+        self.robot_status_ws_connection.run_forever(origin=f'https://{self.prefix}')
 
     def connect_to_robot_position_ws(self):
         self.refresh_expired_token()
@@ -219,7 +219,7 @@ class RobotAPI:
                                                                on_close=on_close,
                                                                on_error=on_error,
                                                                on_message=on_message)
-        self.robot_pose_ws_connection.run_forever()
+        self.robot_pose_ws_connection.run_forever(origin=f'https://{self.prefix}')
 
     def subscribe_to_robot(self, robot_encoding_id: str, time_stamp: float):
         payload = {'operation_cmd': 'subscribe', 'robot_encoding_id': robot_encoding_id, 'time_stamp': time_stamp}

--- a/fleet_adapter_r3/fleet_adapter_r3/RobotClientAPI.py
+++ b/fleet_adapter_r3/fleet_adapter_r3/RobotClientAPI.py
@@ -204,7 +204,7 @@ class RobotAPI:
                                                                  on_close=on_close,
                                                                  on_error=on_error,
                                                                  on_message=on_message)
-        self.robot_status_ws_connection.run_forever()
+        self.robot_status_ws_connection.run_forever(origin=f'https://{self.prefix}')
 
     def connect_to_robot_position_ws(self):
         self.refresh_expired_token()
@@ -236,7 +236,7 @@ class RobotAPI:
                                                                on_close=on_close,
                                                                on_error=on_error,
                                                                on_message=on_message)
-        self.robot_pose_ws_connection.run_forever()
+        self.robot_pose_ws_connection.run_forever(origin=f'https://{self.prefix}')
 
     def subscribe_to_robot(self, robot_encoding_id: str, time_stamp: float):
         payload = {'operation_cmd': 'subscribe', 'robot_encoding_id': robot_encoding_id, 'time_stamp': time_stamp}


### PR DESCRIPTION
## Description
The websocket package used defaults the origin for wss:// using http instead of https. This may cause issue due to CORS as the http domain will be blocked.

## Changes Made
- Explicitly state the origin to use the https:// endpoint instead of using the default origin provided by the websocket package

## Additional Notes